### PR TITLE
Update instructions, use temurin and clj-deps

### DIFF
--- a/docs/install/clojure-cli.md
+++ b/docs/install/clojure-cli.md
@@ -68,7 +68,7 @@ As Clojure itself is packages as a library (`.jar` Java ARchive), any version of
     scoop bucket add extras
     scoop bucket add java
     scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
-    scoop install git 7zip pshazz adoptopenjdk-lts-hotspot clojure leiningen clj-kondo vscode coreutils windows-terminal
+    scoop install git 7zip pshazz temurin-lts-jdk clj-deps leiningen clj-kondo vscode coreutils windows-terminal
     ```
 
 

--- a/docs/install/java.md
+++ b/docs/install/java.md
@@ -79,10 +79,8 @@ If the version is `17` or above, then [jump to the Clojure install page](clojure
     Follow the [scoop-clojure install instructions](https://github.com/littleli/scoop-clojure){target=_blank}, summarized here:
     
     ```bash
-    scoop install git
     scoop bucket add java
-    scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
-    scoop install adoptopenjdk-lts-hotspot
+    scoop install temurin-lts-jdk
     ```
     
     scoop can also be used to [install clojure](install-clojure.md)


### PR DESCRIPTION
Hello 👋🏻 

some instruction changed slightly during christmas, I changed default install method to clj-deps
since it's more compatible with cmd.exe and stuff like that.

Also adoptopenjdk is a legacy project and Temurin is the OSS version of the JDK under Eclipse Foundation umbrella.

Wish you all the best!