### PR TITLE
#464 Fix version command for clojure-lsp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 - dev: changelog-check remove paths-ignore
 - clojure-cli: install deps.edn configuration
 - clojure-cli: `clojure -X:deps tree` examples
-- clojure-cli: `clojure -X:deps pom` 
+- clojure-cli: `clojure -X:deps pom`
 - install: debian packages approach for OpenJDK rather than a specific Ubuntu tab
 - install: recommended OpenJDK versions of 17 and 21 as hint
+- readme: update command Create project (clojure exec)
 
 ## Added
 - button link to Clojure CLI releases changelog to view available versions

--- a/docs/clojure-editors/clojure-lsp/index.md
+++ b/docs/clojure-editors/clojure-lsp/index.md
@@ -13,7 +13,7 @@ Follow your preferred option on the [Clojure LSP installation guide](https://clo
 
 Practicalli downloads the clojure-lsp-native-linux-amd64.zip file from [GitHub release page](https://github.com/clojure-lsp/clojure-lsp/releases)and extracts the `clojure-lsp` binary to `~/.local/bin/clojure-lsp`.
 
-`clojure-lsp -v` in a terminal will test if the the install is working.
+`clojure-lsp --version` in a terminal will test if the the install is working.
 
 ??? HINT "Editors may install Clojure LSP for you"
     Spacemacs LSP layer will prompt to install a language server when first opening a file of a major mode where LSP is enabled.  E.g. when a Clojure related file is opened, the Clojure LSP server is downloaded if not installed (or not found on the Emacs path).

--- a/docs/introduction/clojure-in-15-minutes.md
+++ b/docs/introduction/clojure-in-15-minutes.md
@@ -178,7 +178,7 @@ Only lists are sequences
 (seq? [1 2 3]) ; => false
 ```
 
-Sequences are an interface for logical lists, which can be lazy. "Lazy" means that a sequence of valus are not evaluated until accessed.
+Sequences are an interface for logical lists, which can be lazy. "Lazy" means that a sequence of values are not evaluated until accessed.
 
 A lazy sequence enables the use of large or even an infinite series, like so:
 


### PR DESCRIPTION
This is a documentation change to correct existing documentation to specify the way to invoke the clojure-lsp version from the commandline.

`clojure-lsp --version`

This change worked for this version:
```
clojure-lsp 2023.12.29-12.15.42-nightly
clj-kondo 2023.12.15
```

The original `clojure-lsp -v` did not work:
```

❯ clojure-lsp -v
The following errors occurred while parsing your command:

Unknown option: "-v"

```

Please follow these guidelines when submitting a pull request

- refer to all relevant issues, using `#` followed by the issue number (or paste full link to the issue)
- PR should contain the smallest possible change
- PR should contain a very specific change
- PR should contain only a single commit (squash your commits locally if required)
- Avoid multiple changes across multiple files (raise an issue so we can discuss)
- Avoid a long list of spelling or grammar corrections.  These take too long to review and cherry pick.

## Submitting articles

[Create an issue using the article template](https://github.com/practicalli/blog-content/issues/new?assignees=&labels=article&template=article.md&title=Suggested+article+title),
providing as much detail as possible.

## Website design

Suggestions about website design changes are most welcome, especially in terms of usability and accessibility.

Please raise an issue so we can discuss changes first, especially changes related to aesthetics.

## Review process

All pull requests are reviewed by @practicalli-john and feedback provided, usually the same day but please be patient.
